### PR TITLE
Fix door orientation logic and resource cleanup

### DIFF
--- a/src/Model.cs
+++ b/src/Model.cs
@@ -166,6 +166,9 @@ namespace Game3D
 
                 }
                 GL.DeleteBuffer(vbo);
+                GL.DeleteBuffer(ibo);
+                GL.DeleteVertexArray(vao);
+                disposed = true;
             }
         }
 

--- a/src/models/Door.cs
+++ b/src/models/Door.cs
@@ -105,7 +105,14 @@ namespace Zpg.models
             int x = (int)position.X / 2;
             int z = (int)position.Z / 2;
             // This is a simplification and may need adjustment based on your map layout
-            if (collision[z][x - 1] && collision[z][x - 1])
+            bool east = x + 1 < collision[0].Length && collision[z][x + 1];
+            bool west = x - 1 >= 0 && collision[z][x - 1];
+            bool north = z - 1 >= 0 && collision[z - 1][x];
+            bool south = z + 1 < collision.Length && collision[z + 1][x];
+
+            // If there are walls to the north and south the door lies east-west,
+            // otherwise it is oriented north-south
+            if (north && south && !(east && west))
             {
                 orientation = DoorOrientation.EastWest;
             }


### PR DESCRIPTION
**Summary**

- fix door orientation check to use neighboring cells
- avoid index errors and decide orientation using surrounding walls
- cleanup resources for models

**Testing**

- dotnet --version (fails: command not found)
